### PR TITLE
Use LinearProfile for flywheels

### DIFF
--- a/src/main/java/org/littletonrobotics/frc2024/Constants.java
+++ b/src/main/java/org/littletonrobotics/frc2024/Constants.java
@@ -20,7 +20,7 @@ import org.littletonrobotics.frc2024.util.Alert.AlertType;
  * constants are needed, to reduce verbosity.
  */
 public final class Constants {
-  public static final int loopPeriodMs = 20;
+  public static final double loopPeriodSecs = 0.02;
   private static RobotType robotType = RobotType.DEVBOT;
   public static final boolean tuningMode = true;
 

--- a/src/main/java/org/littletonrobotics/frc2024/RobotContainer.java
+++ b/src/main/java/org/littletonrobotics/frc2024/RobotContainer.java
@@ -211,7 +211,7 @@ public class RobotContainer {
         new Trigger(
             () ->
                 drive.isAutoAimGoalCompleted()
-                    && flywheels.atSetpoint()
+                    && flywheels.atGoal()
                     && superstructure.atArmSetpoint());
     readyToShootTrigger
         .whileTrue(

--- a/src/main/java/org/littletonrobotics/frc2024/RobotContainer.java
+++ b/src/main/java/org/littletonrobotics/frc2024/RobotContainer.java
@@ -217,16 +217,13 @@ public class RobotContainer {
         .a()
         .whileTrue(
             Commands.startEnd(drive::setAutoAimGoal, drive::clearAutoAimGoal)
-                .alongWith(superstructure.aim(), flywheels.shoot())
+                .alongWith(superstructure.aim(), flywheels.shootCommand())
                 .withName("Aim"));
     // Shoot
     Trigger readyToShoot =
         new Trigger(
-            () ->
-                drive.isAutoAimGoalCompleted()
-                    && flywheels.atGoal()
-                    && superstructure.atArmSetpoint());
-    readyToShootTrigger
+            () -> drive.isAutoAimGoalCompleted() && flywheels.atGoal() && superstructure.atGoal());
+    readyToShoot
         .whileTrue(
             Commands.run(
                 () -> controller.getHID().setRumble(GenericHID.RumbleType.kBothRumble, 1.0)))
@@ -240,7 +237,8 @@ public class RobotContainer {
             Commands.parallel(
                     Commands.waitSeconds(0.5),
                     Commands.waitUntil(controller.rightTrigger().negate()))
-                .deadlineWith(rollers.feedShooter(), superstructure.aim(), flywheels.shoot()));
+                .deadlineWith(
+                    rollers.feedShooter(), superstructure.aim(), flywheels.shootCommand()));
     // Intake Floor
     controller
         .leftTrigger()

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelConstants.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelConstants.java
@@ -24,7 +24,12 @@ public class FlywheelConstants {
         case SIMBOT -> new Gains(0.05, 0.0, 0.0, 0.01, 0.00103, 0.0);
       };
 
-  public record FlywheelConfig(int leftID, int rightID, double reduction, double maxAcclerationRpmPerSec, double toleranceRPM) {}
+  public record FlywheelConfig(
+      int leftID,
+      int rightID,
+      double reduction,
+      double maxAcclerationRpmPerSec,
+      double toleranceRPM) {}
 
   public record Gains(double kP, double kI, double kD, double kS, double kV, double kA) {}
 }

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelConstants.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelConstants.java
@@ -10,21 +10,21 @@ package org.littletonrobotics.frc2024.subsystems.flywheels;
 import org.littletonrobotics.frc2024.Constants;
 
 public class FlywheelConstants {
-  public static Config config =
+  public static FlywheelConfig flywheelConfig =
       switch (Constants.getRobot()) {
         case COMPBOT -> null;
-        case DEVBOT -> new Config(5, 4, (1.0 / 2.0), 100.0);
-        case SIMBOT -> new Config(0, 0, (1.0 / 2.0), 100.0);
+        case DEVBOT -> new FlywheelConfig(5, 4, (1.0 / 2.0), 6000.0, 100.0);
+        case SIMBOT -> new FlywheelConfig(0, 0, (1.0 / 2.0), 6000.0, 50.0);
       };
 
   public static Gains gains =
       switch (Constants.getRobot()) {
         case COMPBOT -> null;
         case DEVBOT -> new Gains(0.0006, 0.0, 0.05, 0.33329, 0.00083, 0.0);
-        case SIMBOT -> new Gains(0.0, 0.0, 0.0, 0.09078, 0.00103, 0.0);
+        case SIMBOT -> new Gains(0.05, 0.0, 0.0, 0.01, 0.00103, 0.0);
       };
 
-  public record Config(int leftID, int rightID, double reduction, double toleranceRPM) {}
+  public record FlywheelConfig(int leftID, int rightID, double reduction, double maxAcclerationRpmPerSec, double toleranceRPM) {}
 
   public record Gains(double kP, double kI, double kD, double kS, double kV, double kA) {}
 }

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/Flywheels.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/Flywheels.java
@@ -16,7 +16,6 @@ import java.util.function.DoubleSupplier;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.littletonrobotics.frc2024.Constants;
-import org.littletonrobotics.frc2024.util.EqualsUtil;
 import org.littletonrobotics.frc2024.util.LinearProfile;
 import org.littletonrobotics.frc2024.util.LoggedTunableNumber;
 import org.littletonrobotics.junction.AutoLogOutput;
@@ -81,7 +80,7 @@ public class Flywheels extends SubsystemBase {
     leftProfile = new LinearProfile(maxAcceleration.get(), Constants.loopPeriodSecs);
     rightProfile = new LinearProfile(maxAcceleration.get(), Constants.loopPeriodSecs);
 
-    setDefaultCommand(runOnce(() -> setGoal(Goal.IDLE)).withName("FlywheelsIdle"));
+    setDefaultCommand(runOnce(() -> setGoal(Goal.IDLE)).withName("Flywheels Idle"));
   }
 
   @Override
@@ -134,10 +133,15 @@ public class Flywheels extends SubsystemBase {
       closedLoop = false;
       return; // Don't set a goal
     }
+    // If not already controlling to requested goal
+    // set closed loop false
+    closedLoop = this.goal == goal;
     // Enable close loop
-    leftProfile.setGoal(goal.getLeftGoal(), inputs.leftVelocityRpm);
-    rightProfile.setGoal(goal.getRightGoal(), inputs.rightVelocityRpm);
-    closedLoop = true;
+    if (!closedLoop) {
+      leftProfile.setGoal(goal.getLeftGoal(), inputs.leftVelocityRpm);
+      rightProfile.setGoal(goal.getRightGoal(), inputs.rightVelocityRpm);
+      closedLoop = true;
+    }
     this.goal = goal;
   }
 
@@ -153,8 +157,8 @@ public class Flywheels extends SubsystemBase {
 
   @AutoLogOutput(key = "Flywheels/AtGoal")
   public boolean atGoal() {
-    return EqualsUtil.epsilonEquals(leftProfile.getCurrentSetpoint(), goal.getLeftGoal(), 5)
-        && EqualsUtil.epsilonEquals(rightProfile.getCurrentSetpoint(), goal.getRightGoal(), 5);
+    return leftProfile.getCurrentSetpoint() == goal.getLeftGoal()
+        && rightProfile.getCurrentSetpoint() == goal.getRightGoal();
   }
 
   public Command shootCommand() {

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/Flywheels.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/Flywheels.java
@@ -28,22 +28,22 @@ public class Flywheels extends SubsystemBase {
   private static final LoggedTunableNumber kS = new LoggedTunableNumber("Flywheels/kS", gains.kS());
   private static final LoggedTunableNumber kV = new LoggedTunableNumber("Flywheels/kV", gains.kV());
   private static final LoggedTunableNumber kA = new LoggedTunableNumber("Flywheels/kA", gains.kA());
-  private static final LoggedTunableNumber shootingLeftRPM =
-      new LoggedTunableNumber("Flywheels/ShootingLeftRPM", 6000.0);
-  private static final LoggedTunableNumber shootingRightRPM =
-      new LoggedTunableNumber("Flywheels/ShootingRightRPM", 4000.0);
-  private static final LoggedTunableNumber idleLeftRPM =
-      new LoggedTunableNumber("Flywheels/IdleLeftRPM", 1500.0);
-  private static final LoggedTunableNumber idleRightRPM =
-      new LoggedTunableNumber("Flywheels/IdleRightRPM", 1000.0);
-  private static final LoggedTunableNumber intakingLeftRPM =
-      new LoggedTunableNumber("Flywheels/IntakingLeftRPM", -2000.0);
-  private static final LoggedTunableNumber intakingRightRPM =
-      new LoggedTunableNumber("Flywheels/IntakingRightRPM", -2000.0);
+  private static final LoggedTunableNumber shootingLeftRpm =
+      new LoggedTunableNumber("Flywheels/ShootingLeftRpm", 6000.0);
+  private static final LoggedTunableNumber shootingRightRpm =
+      new LoggedTunableNumber("Flywheels/ShootingRightRpm", 4000.0);
+  private static final LoggedTunableNumber idleLeftRpm =
+      new LoggedTunableNumber("Flywheels/IdleLeftRpm", 1500.0);
+  private static final LoggedTunableNumber idleRightRpm =
+      new LoggedTunableNumber("Flywheels/IdleRightRpm", 1000.0);
+  private static final LoggedTunableNumber intakingRpm =
+      new LoggedTunableNumber("Flywheels/IntakingRpm", -2000.0);
+  private static final LoggedTunableNumber ejectingRpm =
+      new LoggedTunableNumber("Flywheels/EjectingRpm", 1000.0);
   private static final LoggedTunableNumber maxAcceleration =
       new LoggedTunableNumber(
           "Flywheels/MaxAccelerationRpmPerSec", flywheelConfig.maxAcclerationRpmPerSec());
-  
+
   private final FlywheelsIO io;
   private final FlywheelsIOInputsAutoLogged inputs = new FlywheelsIOInputsAutoLogged();
 
@@ -54,6 +54,7 @@ public class Flywheels extends SubsystemBase {
 
   @RequiredArgsConstructor
   public enum Goal {
+    STOP(() -> 0, () -> 0),
     IDLE(idleLeftRpm, idleRightRpm),
     SHOOT(shootingLeftRpm, shootingRightRpm),
     INTAKE(intakingRpm, intakingRpm),
@@ -162,12 +163,11 @@ public class Flywheels extends SubsystemBase {
   }
 
   public Command shootCommand() {
-    return startEnd(() -> setGoal(Goal.SHOOTING), () -> setGoal(Goal.IDLE))
-        .withName("FlywheelsShoot");
+    return startEnd(() -> setGoal(Goal.SHOOT), () -> setGoal(Goal.IDLE)).withName("FlywheelsShoot");
   }
 
   public Command intakeCommand() {
-    return startEnd(() -> setGoal(Goal.INTAKING), () -> setGoal(Goal.IDLE))
+    return startEnd(() -> setGoal(Goal.INTAKE), () -> setGoal(Goal.IDLE))
         .withName("FlywheelsIntake");
   }
 }

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/Flywheels.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/Flywheels.java
@@ -16,6 +16,7 @@ import java.util.function.DoubleSupplier;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.littletonrobotics.frc2024.Constants;
+import org.littletonrobotics.frc2024.util.EqualsUtil;
 import org.littletonrobotics.frc2024.util.LinearProfile;
 import org.littletonrobotics.frc2024.util.LoggedTunableNumber;
 import org.littletonrobotics.junction.AutoLogOutput;
@@ -29,19 +30,17 @@ public class Flywheels extends SubsystemBase {
   private static final LoggedTunableNumber kV = new LoggedTunableNumber("Flywheels/kV", gains.kV());
   private static final LoggedTunableNumber kA = new LoggedTunableNumber("Flywheels/kA", gains.kA());
   private static final LoggedTunableNumber shootingLeftRPM =
-      new LoggedTunableNumber("Superstructure/ShootingLeftRPM", 6000.0);
+      new LoggedTunableNumber("Flywheels/ShootingLeftRPM", 6000.0);
   private static final LoggedTunableNumber shootingRightRPM =
-      new LoggedTunableNumber("Superstructure/ShootingRightRPM", 4000.0);
+      new LoggedTunableNumber("Flywheels/ShootingRightRPM", 4000.0);
   private static final LoggedTunableNumber idleLeftRPM =
-      new LoggedTunableNumber("Superstructure/IdleLeftRPM", 1500.0);
+      new LoggedTunableNumber("Flywheels/IdleLeftRPM", 1500.0);
   private static final LoggedTunableNumber idleRightRPM =
-      new LoggedTunableNumber("Superstructure/IdleRightRPM", 1000.0);
+      new LoggedTunableNumber("Flywheels/IdleRightRPM", 1000.0);
   private static final LoggedTunableNumber intakingLeftRPM =
-      new LoggedTunableNumber("Superstructure/IntakingLeftRPM", -2000.0);
+      new LoggedTunableNumber("Flywheels/IntakingLeftRPM", -2000.0);
   private static final LoggedTunableNumber intakingRightRPM =
-      new LoggedTunableNumber("Superstructure/IntakingRightRPM", -2000.0);
-  private static final LoggedTunableNumber shooterTolerance =
-      new LoggedTunableNumber("Flywheels/ToleranceRPM", flywheelConfig.toleranceRPM());
+      new LoggedTunableNumber("Flywheels/IntakingRightRPM", -2000.0);
   private static final LoggedTunableNumber maxAcceleration =
       new LoggedTunableNumber(
           "Flywheels/MaxAccelerationRpmPerSec", flywheelConfig.maxAcclerationRpmPerSec());
@@ -116,6 +115,9 @@ public class Flywheels extends SubsystemBase {
 
     // Run to setpoint
     if (closedLoop) {
+      // Update goals
+      leftProfile.setGoal(goal.getLeftGoal());
+      rightProfile.setGoal(goal.getRightGoal());
       io.runVelocity(leftProfile.calculateSetpoint(), rightProfile.calculateSetpoint());
     }
 
@@ -149,11 +151,10 @@ public class Flywheels extends SubsystemBase {
     return (inputs.leftVelocityRpm + inputs.rightVelocityRpm) / 2.0;
   }
 
-  @AutoLogOutput(key = "Shooter/AtGoal")
+  @AutoLogOutput(key = "Flywheels/AtGoal")
   public boolean atGoal() {
-    return Math.abs(leftProfile.getCurrentSetpoint() - goal.getLeftGoal()) <= shooterTolerance.get()
-        && Math.abs(rightProfile.getCurrentSetpoint() - goal.getRightGoal())
-            <= shooterTolerance.get();
+    return EqualsUtil.epsilonEquals(leftProfile.getCurrentSetpoint(), goal.getLeftGoal(), 5)
+        && EqualsUtil.epsilonEquals(rightProfile.getCurrentSetpoint(), goal.getRightGoal(), 5);
   }
 
   public Command shootCommand() {

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelsIOSim.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelsIOSim.java
@@ -18,9 +18,9 @@ import edu.wpi.first.wpilibj.simulation.FlywheelSim;
 
 public class FlywheelsIOSim implements FlywheelsIO {
   private final FlywheelSim leftSim =
-      new FlywheelSim(DCMotor.getKrakenX60Foc(1), config.reduction(), 0.00363458292);
+      new FlywheelSim(DCMotor.getKrakenX60Foc(1), flywheelConfig.reduction(), 0.00363458292);
   private final FlywheelSim rightSim =
-      new FlywheelSim(DCMotor.getKrakenX60Foc(1), config.reduction(), 0.00363458292);
+      new FlywheelSim(DCMotor.getKrakenX60Foc(1), flywheelConfig.reduction(), 0.00363458292);
 
   private final PIDController leftController =
       new PIDController(gains.kP(), gains.kI(), gains.kD());

--- a/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelsIOSparkFlex.java
+++ b/src/main/java/org/littletonrobotics/frc2024/subsystems/flywheels/FlywheelsIOSparkFlex.java
@@ -31,8 +31,8 @@ public class FlywheelsIOSparkFlex implements FlywheelsIO {
 
   public FlywheelsIOSparkFlex() {
     // Init Hardware
-    leftMotor = new CANSparkFlex(config.leftID(), CANSparkFlex.MotorType.kBrushless);
-    rightMotor = new CANSparkFlex(config.rightID(), CANSparkFlex.MotorType.kBrushless);
+    leftMotor = new CANSparkFlex(flywheelConfig.leftID(), CANSparkFlex.MotorType.kBrushless);
+    rightMotor = new CANSparkFlex(flywheelConfig.rightID(), CANSparkFlex.MotorType.kBrushless);
     leftEncoder = leftMotor.getEncoder();
     rightEncoder = rightMotor.getEncoder();
 
@@ -72,15 +72,15 @@ public class FlywheelsIOSparkFlex implements FlywheelsIO {
   @Override
   public void updateInputs(FlywheelsIOInputs inputs) {
     inputs.leftPositionRads =
-        Units.rotationsToRadians(leftEncoder.getPosition()) / config.reduction();
-    inputs.leftVelocityRpm = leftEncoder.getVelocity() / config.reduction();
+        Units.rotationsToRadians(leftEncoder.getPosition()) / flywheelConfig.reduction();
+    inputs.leftVelocityRpm = leftEncoder.getVelocity() / flywheelConfig.reduction();
     inputs.leftAppliedVolts = leftMotor.getAppliedOutput();
     inputs.leftOutputCurrent = leftMotor.getOutputCurrent();
     inputs.leftTempCelsius = leftMotor.getMotorTemperature();
 
     inputs.rightPositionRads =
-        Units.rotationsToRadians(rightEncoder.getPosition()) / config.reduction();
-    inputs.rightVelocityRpm = rightEncoder.getVelocity() / config.reduction();
+        Units.rotationsToRadians(rightEncoder.getPosition()) / flywheelConfig.reduction();
+    inputs.rightVelocityRpm = rightEncoder.getVelocity() / flywheelConfig.reduction();
     inputs.rightAppliedVolts = rightMotor.getAppliedOutput();
     inputs.rightOutputCurrent = rightMotor.getOutputCurrent();
     inputs.rightTempCelsius = rightMotor.getMotorTemperature();
@@ -95,13 +95,13 @@ public class FlywheelsIOSparkFlex implements FlywheelsIO {
   @Override
   public void runVelocity(double leftRpm, double rightRpm) {
     leftController.setReference(
-        leftRpm * config.reduction(),
+        leftRpm * flywheelConfig.reduction(),
         CANSparkBase.ControlType.kVelocity,
         0,
         ff.calculate(leftRpm),
         SparkPIDController.ArbFFUnits.kVoltage);
     rightController.setReference(
-        rightRpm * config.reduction(),
+        rightRpm * flywheelConfig.reduction(),
         CANSparkBase.ControlType.kVelocity,
         0,
         ff.calculate(rightRpm),

--- a/src/main/java/org/littletonrobotics/frc2024/util/LinearProfile.java
+++ b/src/main/java/org/littletonrobotics/frc2024/util/LinearProfile.java
@@ -56,6 +56,9 @@ public class LinearProfile {
    * @return Setpoint to send to motors
    */
   public double calculateSetpoint() {
+    if (EqualsUtil.epsilonEquals(goal, currentSetpoint)) {
+      return currentSetpoint;
+    }
     if (goal > currentSetpoint) {
       currentSetpoint += dv;
       if (currentSetpoint > goal) {

--- a/src/main/java/org/littletonrobotics/frc2024/util/LinearProfile.java
+++ b/src/main/java/org/littletonrobotics/frc2024/util/LinearProfile.java
@@ -18,7 +18,7 @@ public class LinearProfile {
   @Getter @Setter private double goal = 0;
 
   /**
-   * Creates a new LinearProfiler
+   * Creates a new LinearProfile
    *
    * @param maxAcceleration The max ramp rate in velocity in rpm/sec
    * @param period Period of control loop (0.02)

--- a/src/main/java/org/littletonrobotics/frc2024/util/LinearProfile.java
+++ b/src/main/java/org/littletonrobotics/frc2024/util/LinearProfile.java
@@ -1,0 +1,72 @@
+// Copyright (c) 2024 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file at
+// the root directory of this project.
+
+package org.littletonrobotics.frc2024.util;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/** Ramps up and down to setpoint for velocity closed loop control */
+public class LinearProfile {
+  private double dv;
+  @Getter private final double period;
+  @Getter private double currentSetpoint = 0;
+  @Getter @Setter private double goal = 0;
+
+  /**
+   * Creates a new LinearProfiler
+   *
+   * @param maxAcceleration The max ramp rate in velocity in rpm/sec
+   * @param period Period of control loop (0.02)
+   */
+  public LinearProfile(double maxAcceleration, double period) {
+    this.period = period;
+    setMaxAcceleration(maxAcceleration);
+  }
+
+  /** Set the max acceleration constraint in rpm/sec */
+  public void setMaxAcceleration(double maxAcceleration) {
+    dv = maxAcceleration * period;
+  }
+
+  /**
+   * Sets the target setpoint, starting from the current speed
+   *
+   * @param goal Target setpoint
+   * @param currentSpeed Current speed, to be used as the starting setpoint
+   */
+  public void setGoal(double goal, double currentSpeed) {
+    this.goal = goal;
+    currentSetpoint = currentSpeed;
+  }
+
+  /** Resets target setpoint and current setpoint */
+  public void reset() {
+    currentSetpoint = 0;
+    goal = 0;
+  }
+
+  /**
+   * Returns the current setpoint to send to motors
+   *
+   * @return Setpoint to send to motors
+   */
+  public double calculateSetpoint() {
+    if (goal > currentSetpoint) {
+      currentSetpoint += dv;
+      if (currentSetpoint > goal) {
+        currentSetpoint = goal;
+      }
+    } else if (goal < currentSetpoint) {
+      currentSetpoint -= dv;
+      if (currentSetpoint < goal) {
+        currentSetpoint = goal;
+      }
+    }
+    return currentSetpoint;
+  }
+}


### PR DESCRIPTION
Switched to using a linear profile to track setpoint and monitor check if flywheels are at the goal rpm. Tuned the sim gains to rev in ~1 sec.