### PR TITLE
Critical pose fudge factors

### DIFF
--- a/src/main/java/org/littletonrobotics/frc2024/FudgeFactors.java
+++ b/src/main/java/org/littletonrobotics/frc2024/FudgeFactors.java
@@ -11,9 +11,7 @@ import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.wpilibj.DriverStation;
 import lombok.Builder;
 
-/**
- * Fudge factors for critical field locations which can be tuned per alliance at events.
- */
+/** Fudge factors for critical field locations which can be tuned per alliance at events. */
 public final class FudgeFactors {
   @Builder
   public static class FudgedTransform {

--- a/src/main/java/org/littletonrobotics/frc2024/FudgeFactors.java
+++ b/src/main/java/org/littletonrobotics/frc2024/FudgeFactors.java
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 FRC 6328
+// http://github.com/Mechanical-Advantage
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file at
+// the root directory of this project.
+
+package org.littletonrobotics.frc2024;
+
+import edu.wpi.first.math.geometry.Transform2d;
+import edu.wpi.first.wpilibj.DriverStation;
+import lombok.Builder;
+
+/**
+ * Fudge factors for critical field locations which can be tuned per alliance at events.
+ */
+public final class FudgeFactors {
+  @Builder
+  public static class FudgedTransform {
+    @Builder.Default private final Transform2d red = new Transform2d();
+
+    @Builder.Default private final Transform2d blue = new Transform2d();
+
+    public Transform2d getTransform() {
+      return DriverStation.getAlliance()
+          .map(alliance -> alliance == DriverStation.Alliance.Red ? red : blue)
+          .orElseGet(Transform2d::new);
+    }
+  }
+
+  private FudgeFactors() {}
+
+  public static final FudgedTransform speaker = FudgedTransform.builder().build();
+
+  public static final FudgedTransform amp = FudgedTransform.builder().build();
+
+  public static final FudgedTransform centerPodiumAmpChain = FudgedTransform.builder().build();
+
+  public static final FudgedTransform centerAmpSourceChain = FudgedTransform.builder().build();
+
+  public static final FudgedTransform centerSourcePodiumChain = FudgedTransform.builder().build();
+}

--- a/src/main/java/org/littletonrobotics/frc2024/RobotContainer.java
+++ b/src/main/java/org/littletonrobotics/frc2024/RobotContainer.java
@@ -544,7 +544,9 @@ public class RobotContainer {
               AllianceFlipUtil.apply(
                   new Pose2d(FieldConstants.ampCenter, new Rotation2d(-Math.PI / 2.0)));
           var finalPose =
-              ampCenterRotated.transformBy(GeomUtil.toTransform2d(Units.inchesToMeters(20.0), 0));
+              ampCenterRotated
+                  .transformBy(GeomUtil.toTransform2d(Units.inchesToMeters(20.0), 0))
+                  .transformBy(FudgeFactors.amp.getTransform());
           double distance =
               robotState
                   .getEstimatedPose()

--- a/src/main/java/org/littletonrobotics/frc2024/RobotState.java
+++ b/src/main/java/org/littletonrobotics/frc2024/RobotState.java
@@ -212,7 +212,8 @@ public class RobotState {
     Transform2d fieldToTarget =
         AllianceFlipUtil.apply(FieldConstants.Speaker.centerSpeakerOpening)
             .toTranslation2d()
-            .toTransform2d();
+            .toTransform2d()
+            .plus(FudgeFactors.speaker.getTransform());
     Pose2d fieldToPredictedVehicle =
         lookaheadDisable.getAsBoolean()
             ? getEstimatedPose()

--- a/src/main/java/org/littletonrobotics/frc2024/commands/ClimbingCommands.java
+++ b/src/main/java/org/littletonrobotics/frc2024/commands/ClimbingCommands.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 import lombok.experimental.ExtensionMethod;
+import org.littletonrobotics.frc2024.FudgeFactors;
 import org.littletonrobotics.frc2024.RobotState;
 import org.littletonrobotics.frc2024.subsystems.drive.Drive;
 import org.littletonrobotics.frc2024.subsystems.rollers.Rollers;
@@ -38,16 +39,25 @@ public class ClimbingCommands {
   private static final LoggedTunableNumber chainToFront =
       new LoggedTunableNumber("ClimbingCommands/ChainToFrontOffset", 0.9);
 
-  private static final List<Pose2d> centeredClimbedPosesNoOffset =
+  private static final List<Supplier<Pose2d>> centeredClimbedPosesNoOffset =
       List.of(
-          Stage.centerPodiumAmpChain, Stage.centerAmpSourceChain, Stage.centerSourcePodiumChain);
+          () ->
+              Stage.centerPodiumAmpChain.transformBy(
+                  FudgeFactors.centerPodiumAmpChain.getTransform()),
+          () ->
+              Stage.centerAmpSourceChain.transformBy(
+                  FudgeFactors.centerAmpSourceChain.getTransform()),
+          () ->
+              Stage.centerSourcePodiumChain.transformBy(
+                  FudgeFactors.centerSourcePodiumChain.getTransform()));
 
   private static final Supplier<Pose2d> nearestClimbedPose =
       () -> {
         Pose2d currentPose = RobotState.getInstance().getEstimatedPose();
         List<Pose2d> climbedPoses =
             centeredClimbedPosesNoOffset.stream()
-                .map(pose -> AllianceFlipUtil.apply(pose))
+                .map(Supplier::get)
+                .map(AllianceFlipUtil::apply)
                 .toList();
         return currentPose.nearest(climbedPoses);
       };


### PR DESCRIPTION
Add per alliance fudge factors for the speaker (in case of left to right shooting error, unlikely?), amp, and all climbing locations.